### PR TITLE
Add Auto-Monitor favorite team / competitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.cursor/*.log
+MenuScores.xcodeproj/project.xcworkspace/xcuserdata/billylo.xcuserdatad/UserInterfaceState.xcuserstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .cursor/*.log
 MenuScores.xcodeproj/project.xcworkspace/xcuserdata/billylo.xcuserdatad/UserInterfaceState.xcuserstate
+.DS_Store

--- a/MenuScores.xcodeproj/project.pbxproj
+++ b/MenuScores.xcodeproj/project.pbxproj
@@ -454,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evergreenlabs.MenuScores;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -491,7 +491,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.evergreenlabs.MenuScores;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MenuScores.xcodeproj/project.pbxproj
+++ b/MenuScores.xcodeproj/project.pbxproj
@@ -433,9 +433,10 @@
 				CODE_SIGN_ENTITLEMENTS = MenuScores/MenuScores.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"MenuScores/Preview Content\"";
+				DEVELOPMENT_TEAM = X5J5T5UT6J;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -444,6 +445,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MenuScores/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MenuScores;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -452,8 +454,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = daniyalmaster.MenuScores;
+				MARKETING_VERSION = 2.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.evergreenlabs.MenuScores;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -468,9 +470,10 @@
 				CODE_SIGN_ENTITLEMENTS = MenuScores/MenuScores.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"MenuScores/Preview Content\"";
+				DEVELOPMENT_TEAM = X5J5T5UT6J;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -479,6 +482,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MenuScores/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MenuScores;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -487,8 +491,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = daniyalmaster.MenuScores;
+				MARKETING_VERSION = 2.3.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.evergreenlabs.MenuScores;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/MenuScores.xcodeproj/xcuserdata/billylo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/MenuScores.xcodeproj/xcuserdata/billylo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>MenuScores.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/MenuScores/MenuScoresApp.swift
+++ b/MenuScores/MenuScoresApp.swift
@@ -32,18 +32,7 @@ struct MenuScoresApp: App {
     @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
 
     private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
-        }
+        RefreshInterval.timeInterval(for: selectedOption)
     }
 
     // Toggled League Settings
@@ -116,72 +105,124 @@ struct MenuScoresApp: App {
     @AppStorage("autoMonitorEnabled") private var autoMonitorEnabled = false
     @AppStorage("autoMonitorFavorite") private var autoMonitorFavorite = ""
 
+    @MainActor
+    private func enabledLeagueCodes() -> [String] {
+        buildScoreboardEventSources().map(\.league) + buildTennisSources().map(\.league)
+    }
+
     private func refreshAllLeagues() async {
-        if enableNHL { await nhlVM.populateGames(from: Scoreboard.Urls.nhl) }
+        for code in enabledLeagueCodes() {
+            await refreshLeague(code)
+        }
+    }
 
-        if enableHNCAAM { await hncaamVM.populateGames(from: Scoreboard.Urls.hncaam) }
-        if enableHNCAAF { await hncaafVM.populateGames(from: Scoreboard.Urls.hncaaf) }
+    @MainActor
+    private func refreshLeague(_ code: String) async {
+        switch code {
+        case "NHL": await nhlVM.populateGames(from: Scoreboard.Urls.nhl)
+        case "HNCAAM": await hncaamVM.populateGames(from: Scoreboard.Urls.hncaam)
+        case "HNCAAF": await hncaafVM.populateGames(from: Scoreboard.Urls.hncaaf)
+        case "NBA": await nbaVM.populateGames(from: Scoreboard.Urls.nba)
+        case "WNBA": await wnbaVM.populateGames(from: Scoreboard.Urls.wnba)
+        case "NCAA M": await ncaamVM.populateGames(from: Scoreboard.Urls.ncaam)
+        case "NCAA F": await ncaafVM.populateGames(from: Scoreboard.Urls.ncaaf)
+        case "NFL": await nflVM.populateGames(from: Scoreboard.Urls.nfl)
+        case "FNCAA": await fncaaVM.populateGames(from: Scoreboard.Urls.fncaa)
+        case "MLB": await mlbVM.populateGames(from: Scoreboard.Urls.mlb)
+        case "BNCAA": await bncaaVM.populateGames(from: Scoreboard.Urls.bncaa)
+        case "SNCAA": await sncaaVM.populateGames(from: Scoreboard.Urls.sncaa)
+        case "F1": await f1VM.populateGames(from: Scoreboard.Urls.f1)
+        case "NC": await ncVM.populateGames(from: Scoreboard.Urls.nc)
+        case "NCS": await ncsVM.populateGames(from: Scoreboard.Urls.ncs)
+        case "NCT": await nctVM.populateGames(from: Scoreboard.Urls.nct)
+        case "IRL": await irlVM.populateGames(from: Scoreboard.Urls.irl)
+        case "PGA": await pgaVM.populateGames(from: Scoreboard.Urls.pga)
+        case "LPGA": await lpgaVM.populateGames(from: Scoreboard.Urls.lpga)
+        case "MLS": await mlsVM.populateGames(from: Scoreboard.Urls.mls)
+        case "NWSL": await nwslVM.populateGames(from: Scoreboard.Urls.nwsl)
+        case "UEFA": await uefaVM.populateGames(from: Scoreboard.Urls.uefa)
+        case "EUEFA": await euefaVM.populateGames(from: Scoreboard.Urls.euefa)
+        case "WUEFA": await wuefaVM.populateGames(from: Scoreboard.Urls.wuefa)
+        case "EPL": await eplVM.populateGames(from: Scoreboard.Urls.epl)
+        case "WEPL": await weplVM.populateGames(from: Scoreboard.Urls.wepl)
+        case "ESP": await espVM.populateGames(from: Scoreboard.Urls.esp)
+        case "GER": await gerVM.populateGames(from: Scoreboard.Urls.ger)
+        case "ITA": await itaVM.populateGames(from: Scoreboard.Urls.ita)
+        case "MEX": await mexVM.populateGames(from: Scoreboard.Urls.mex)
+        case "FRA": await fraVM.populateGames(from: Scoreboard.Urls.fra)
+        case "NED": await nedVM.populateGames(from: Scoreboard.Urls.ned)
+        case "POR": await porVM.populateGames(from: Scoreboard.Urls.por)
+        case "FFWC": await ffwcVM.populateGames(from: Scoreboard.Urls.ffwc)
+        case "FFWWC": await ffwwcVM.populateGames(from: Scoreboard.Urls.ffwwc)
+        case "FFWCQUEFA": await ffwcquefaVM.populateGames(from: Scoreboard.Urls.ffwcquefa)
+        case "CONMEBOL": await conmebolVM.populateGames(from: Scoreboard.Urls.conmebol)
+        case "CONCACAF": await concacafVM.populateGames(from: Scoreboard.Urls.concacaf)
+        case "CAF": await cafVM.populateGames(from: Scoreboard.Urls.caf)
+        case "AFC": await afcVM.populateGames(from: Scoreboard.Urls.afc)
+        case "OFC": await ofcVM.populateGames(from: Scoreboard.Urls.ofc)
+        case "ATP": await atpVM.populateTennis(from: Scoreboard.Urls.atp)
+        case "WTA": await wtaVM.populateTennis(from: Scoreboard.Urls.wta)
+        case "NLL": await nllVM.populateGames(from: Scoreboard.Urls.nll)
+        case "PLL": await pllVM.populateGames(from: Scoreboard.Urls.pll)
+        case "LNCAAM": await lncaamVM.populateGames(from: Scoreboard.Urls.lncaam)
+        case "LNCAAF": await lncaafVM.populateGames(from: Scoreboard.Urls.lncaaf)
+        case "VNCAAM": await vncaamVM.populateGames(from: Scoreboard.Urls.vncaam)
+        case "VNCAAF": await vncaafVM.populateGames(from: Scoreboard.Urls.vncaaf)
+        case "OMIHC": await omihcVM.populateGames(from: Scoreboard.Urls.omihc)
+        case "OWIHC": await owihcVM.populateGames(from: Scoreboard.Urls.owihc)
+        default: break
+        }
+    }
 
-        if enableNBA { await nbaVM.populateGames(from: Scoreboard.Urls.nba) }
-        if enableWNBA { await wnbaVM.populateGames(from: Scoreboard.Urls.wnba) }
-        if enableNCAAM { await ncaamVM.populateGames(from: Scoreboard.Urls.ncaam) }
-        if enableNCAAF { await ncaafVM.populateGames(from: Scoreboard.Urls.ncaaf) }
+    private var hasPinnedOrActiveNotch: Bool {
+        let hasPinnedGame = !currentGameID.isEmpty && currentGameID != "0"
+        return hasPinnedGame || NotchViewModel.shared.notch != nil
+    }
 
-        if enableNFL { await nflVM.populateGames(from: Scoreboard.Urls.nfl) }
-        if enableFNCAA { await fncaaVM.populateGames(from: Scoreboard.Urls.fncaa) }
+    @MainActor
+    private func reconcileBackgroundRefresh() {
+        let favoriteActive = autoMonitorEnabled
+            && !AutoMonitorFavorite.normalizedQuery(autoMonitorFavorite).isEmpty
+        RefreshCoordinator.shared.setShouldRun(favoriteActive || hasPinnedOrActiveNotch)
+    }
 
-        if enableMLB { await mlbVM.populateGames(from: Scoreboard.Urls.mlb) }
-        if enableBNCAA { await bncaaVM.populateGames(from: Scoreboard.Urls.bncaa) }
-        if enableSNCAA { await sncaaVM.populateGames(from: Scoreboard.Urls.sncaa) }
+    @MainActor
+    private func backgroundRefreshTick() async {
+        var leaguesToRefresh = Set<String>()
 
-        if enableF1 { await f1VM.populateGames(from: Scoreboard.Urls.f1) }
-        if enableNC { await ncVM.populateGames(from: Scoreboard.Urls.nc) }
-        if enableNCS { await ncsVM.populateGames(from: Scoreboard.Urls.ncs) }
-        if enableNCT { await nctVM.populateGames(from: Scoreboard.Urls.nct) }
-        if enableIRL { await irlVM.populateGames(from: Scoreboard.Urls.irl) }
+        if autoMonitorEnabled {
+            leaguesToRefresh.formUnion(AutoMonitorHub.shared.leaguesToRefreshThisTick())
+        }
 
-        if enablePGA { await pgaVM.populateGames(from: Scoreboard.Urls.pga) }
-        if enableLPGA { await lpgaVM.populateGames(from: Scoreboard.Urls.lpga) }
+        if hasPinnedOrActiveNotch {
+            let league = LeagueSelectionModel.shared.currentLeague
+            if !league.isEmpty {
+                leaguesToRefresh.insert(league)
+            }
+        }
 
-        if enableMLS { await mlsVM.populateGames(from: Scoreboard.Urls.mls) }
-        if enableNWSL { await nwslVM.populateGames(from: Scoreboard.Urls.nwsl) }
-        if enableUEFA { await uefaVM.populateGames(from: Scoreboard.Urls.uefa) }
-        if enableEUEFA { await euefaVM.populateGames(from: Scoreboard.Urls.euefa) }
-        if enableWUEFA { await wuefaVM.populateGames(from: Scoreboard.Urls.wuefa) }
-        if enableEPL { await eplVM.populateGames(from: Scoreboard.Urls.epl) }
-        if enableWEPL { await weplVM.populateGames(from: Scoreboard.Urls.wepl) }
-        if enableESP { await espVM.populateGames(from: Scoreboard.Urls.esp) }
-        if enableGER { await gerVM.populateGames(from: Scoreboard.Urls.ger) }
-        if enableITA { await itaVM.populateGames(from: Scoreboard.Urls.ita) }
-        if enableMEX { await mexVM.populateGames(from: Scoreboard.Urls.mex) }
-        if enableFRA { await fraVM.populateGames(from: Scoreboard.Urls.fra) }
-        if enableNED { await nedVM.populateGames(from: Scoreboard.Urls.ned) }
-        if enablePOR { await porVM.populateGames(from: Scoreboard.Urls.por) }
+        for league in leaguesToRefresh {
+            await refreshLeague(league)
+        }
 
-        if enableFFWC { await ffwcVM.populateGames(from: Scoreboard.Urls.ffwc) }
-        if enableFFWWC { await ffwwcVM.populateGames(from: Scoreboard.Urls.ffwwc) }
-        if enableFFWCQUEFA { await ffwcquefaVM.populateGames(from: Scoreboard.Urls.ffwcquefa) }
-        if enableCONMEBOL { await conmebolVM.populateGames(from: Scoreboard.Urls.conmebol) }
-        if enableCONCACAF { await concacafVM.populateGames(from: Scoreboard.Urls.concacaf) }
-        if enableCAF { await cafVM.populateGames(from: Scoreboard.Urls.caf) }
-        if enableAFC { await afcVM.populateGames(from: Scoreboard.Urls.afc) }
-        if enableOFC { await ofcVM.populateGames(from: Scoreboard.Urls.ofc) }
+        if autoMonitorEnabled {
+            AutoMonitorHub.shared.scanAndApply()
+        }
 
-        if enableATP { await atpVM.populateTennis(from: Scoreboard.Urls.atp) }
-        if enableWTA { await wtaVM.populateTennis(from: Scoreboard.Urls.wta) }
-
-//        if enableUFC { await ufcVM.populateGames(from: Scoreboard.Urls.ufc) }
-
-        if enableNLL { await nllVM.populateGames(from: Scoreboard.Urls.nll) }
-        if enablePLL { await pllVM.populateGames(from: Scoreboard.Urls.pll) }
-        if enableLNCAAM { await lncaamVM.populateGames(from: Scoreboard.Urls.lncaam) }
-        if enableLNCAAF { await lncaafVM.populateGames(from: Scoreboard.Urls.lncaaf) }
-
-        if enableVNCAAM { await vncaamVM.populateGames(from: Scoreboard.Urls.vncaam) }
-        if enableVNCAAF { await vncaafVM.populateGames(from: Scoreboard.Urls.vncaaf) }
-
-        if enableOMIHC { await omihcVM.populateGames(from: Scoreboard.Urls.omihc) }
-        if enableOWIHC { await owihcVM.populateGames(from: Scoreboard.Urls.owihc) }
+        if hasPinnedOrActiveNotch {
+            let league = LeagueSelectionModel.shared.currentLeague
+            guard !league.isEmpty else { return }
+            PinnedGameSync.syncStandardEvent(
+                gameID: currentGameID,
+                league: league,
+                eventSources: buildScoreboardEventSources(),
+                currentTitle: &currentTitle,
+                currentGameState: &currentGameState,
+                previousGameState: &previousGameState,
+                notiGameStart: notiGameStart,
+                notiGameComplete: notiGameComplete
+            )
+        }
     }
 
     @MainActor
@@ -381,18 +422,19 @@ struct MenuScoresApp: App {
 
     var body: some Scene {
         MenuBarExtra {
-            if !currentTitle.isEmpty {
-                Button {
-                    openSetGameDetails()
-                } label: {
-                    HStack {
-                        Image(systemName: "info.circle")
-                        Text("Open Set Game Details")
-                    }
+            Button {
+                openSetGameDetails()
+            } label: {
+                HStack {
+                    Image(systemName: "info.circle")
+                    Text("Open Set Game Details")
                 }
-
-                Divider()
             }
+            .disabled(currentTitle.isEmpty)
+            .stableMenuBarItem("menu-open-details")
+
+            Divider()
+                .stableMenuBarItem("menu-divider-open-details")
 
             if enableNHL {
                 HockeyMenu(
@@ -1071,6 +1113,7 @@ struct MenuScoresApp: App {
             }
 
             Divider()
+                .stableMenuBarItem("menu-divider-footer")
 
             if enableNotch {
                 Picker("Choose Display", selection: $notchScreenIndex) {
@@ -1079,6 +1122,7 @@ struct MenuScoresApp: App {
                             .tag(index)
                     }
                 }
+                .stableMenuBarItem("menu-picker-display")
             }
 
             Button {
@@ -1089,6 +1133,7 @@ struct MenuScoresApp: App {
                 Text("Refresh")
             }
             .keyboardShortcut("r")
+            .stableMenuBarItem("menu-refresh")
 
             Button {
                 currentTitle = ""
@@ -1106,13 +1151,16 @@ struct MenuScoresApp: App {
                     NotchViewModel.shared.currentGameState = ""
                     NotchViewModel.shared.previousGameState = ""
                     NotchViewModel.shared.notch = nil
+                    reconcileBackgroundRefresh()
                 }
             } label: {
                 Text("Clear Set Game")
             }
             .keyboardShortcut("c")
+            .stableMenuBarItem("menu-clear-game")
 
             Divider()
+                .stableMenuBarItem("menu-divider-settings")
 
             if #available(macOS 14, *) {
                 Button {
@@ -1124,6 +1172,7 @@ struct MenuScoresApp: App {
                     Text("Preferences")
                 }
                 .keyboardShortcut(",")
+                .stableMenuBarItem("menu-preferences")
             }
 
             Button {
@@ -1132,6 +1181,7 @@ struct MenuScoresApp: App {
                 Text("Quit")
             }
             .keyboardShortcut("q")
+            .stableMenuBarItem("menu-quit")
         } label: {
             HStack {
                 Image(systemName: "dot.radiowaves.left.and.right")
@@ -1139,29 +1189,35 @@ struct MenuScoresApp: App {
             }
             .onChange(of: currentGameID) { _ in
                 syncCurrentGameDetailURL()
+                reconcileBackgroundRefresh()
+            }
+            .onChange(of: autoMonitorEnabled) { _ in reconcileBackgroundRefresh() }
+            .onChange(of: autoMonitorFavorite) { _ in reconcileBackgroundRefresh() }
+            .onChange(of: selectedOption) { _ in
+                RefreshCoordinator.shared.setInterval(refreshInterval)
             }
             .onAppear {
                 AutoMonitorHub.shared.configure(
                     isEnabled: { autoMonitorEnabled },
                     favoriteRaw: { autoMonitorFavorite },
-                    refreshAll: { await refreshAllLeagues() },
+                    enabledLeagues: { enabledLeagueCodes() },
                     eventSources: { buildScoreboardEventSources() },
                     tennisSources: { buildTennisSources() },
-                    apply: { title, id, state in
+                    apply: { title, id, state, league in
                         let priorForTransition = (currentGameID == id) ? currentGameState : nil
                         currentTitle = title
                         currentGameID = id
                         currentGameState = state
                         previousGameState = priorForTransition
+                        LeagueSelectionModel.shared.currentLeague = league
                         syncCurrentGameDetailURL()
                     }
                 )
-                Task { await AutoMonitorHub.shared.tick() }
-            }
-            .onReceive(
-                Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-            ) { _ in
-                Task { await AutoMonitorHub.shared.tick() }
+                RefreshCoordinator.shared.configure(interval: refreshInterval) {
+                    await backgroundRefreshTick()
+                }
+                reconcileBackgroundRefresh()
+                Task { await backgroundRefreshTick() }
             }
         }
 

--- a/MenuScores/MenuScoresApp.swift
+++ b/MenuScores/MenuScoresApp.swift
@@ -5,10 +5,20 @@
 //  Created by Daniyal Master on 2025-05-03.
 //
 
+import AppKit
 import SwiftUI
 
 class LeagueSelectionModel: ObservableObject {
     @Published var currentLeague: String = ""
+    @Published var currentGameDetailURL: String = ""
+
+    func setPinnedDetailURL(from event: Event) {
+        currentGameDetailURL = event.links?.first?.href ?? ""
+    }
+
+    func setPinnedDetailURL(from event: TennisEvent) {
+        currentGameDetailURL = event.links?.first?.href ?? ""
+    }
 }
 
 extension LeagueSelectionModel {
@@ -247,6 +257,40 @@ struct MenuScoresApp: App {
         return rows
     }
 
+    @MainActor
+    private func resolveDetailsURL(for gameID: String) -> URL? {
+        eventDetailsURL(for: gameID, in: buildScoreboardEventSources())
+            ?? tennisDetailsURL(for: gameID, in: buildTennisSources())
+    }
+
+    @MainActor
+    private func syncCurrentGameDetailURL() {
+        let model = LeagueSelectionModel.shared
+        if model.currentGameDetailURL.isEmpty,
+           let resolved = resolveDetailsURL(for: currentGameID)
+        {
+            model.currentGameDetailURL = resolved.absoluteString
+        }
+    }
+
+    @MainActor
+    private func openSetGameDetails() {
+        guard !currentTitle.isEmpty else { return }
+
+        let model = LeagueSelectionModel.shared
+        let urlString = model.currentGameDetailURL.isEmpty
+            ? resolveDetailsURL(for: currentGameID)?.absoluteString
+            : model.currentGameDetailURL
+
+        guard let urlString, !urlString.isEmpty, let url = URL(string: urlString) else { return }
+
+        if model.currentGameDetailURL.isEmpty {
+            model.currentGameDetailURL = urlString
+        }
+
+        NSWorkspace.shared.open(url)
+    }
+
     // Notification Settings
 
     @AppStorage("notiGameStart") private var notiGameStart = false
@@ -337,6 +381,19 @@ struct MenuScoresApp: App {
 
     var body: some Scene {
         MenuBarExtra {
+            if !currentTitle.isEmpty {
+                Button {
+                    openSetGameDetails()
+                } label: {
+                    HStack {
+                        Image(systemName: "info.circle")
+                        Text("Open Set Game Details")
+                    }
+                }
+
+                Divider()
+            }
+
             if enableNHL {
                 HockeyMenu(
                     title: "NHL",
@@ -1037,6 +1094,7 @@ struct MenuScoresApp: App {
                 currentTitle = ""
                 currentGameID = ""
                 currentGameState = ""
+                LeagueSelectionModel.shared.currentGameDetailURL = ""
                 previousGameState = nil
 
                 Task {
@@ -1079,6 +1137,9 @@ struct MenuScoresApp: App {
                 Image(systemName: "dot.radiowaves.left.and.right")
                 Text(currentTitle)
             }
+            .onChange(of: currentGameID) { _ in
+                syncCurrentGameDetailURL()
+            }
             .onAppear {
                 AutoMonitorHub.shared.configure(
                     isEnabled: { autoMonitorEnabled },
@@ -1092,6 +1153,7 @@ struct MenuScoresApp: App {
                         currentGameID = id
                         currentGameState = state
                         previousGameState = priorForTransition
+                        syncCurrentGameDetailURL()
                     }
                 )
                 Task { await AutoMonitorHub.shared.tick() }

--- a/MenuScores/MenuScoresApp.swift
+++ b/MenuScores/MenuScoresApp.swift
@@ -208,7 +208,7 @@ struct MenuScoresApp: App {
         if enableEUEFA { rows.append(("EUEFA", euefaVM.games)) }
         if enableWUEFA { rows.append(("WUEFA", wuefaVM.games)) }
         if enableEPL { rows.append(("EPL", eplVM.games)) }
-        if enableWEPL { rows.append(("wepl", weplVM.games)) }
+        if enableWEPL { rows.append(("WEPL", weplVM.games)) }
         if enableESP { rows.append(("ESP", espVM.games)) }
         if enableGER { rows.append(("GER", gerVM.games)) }
         if enableITA { rows.append(("ITA", itaVM.games)) }
@@ -337,26 +337,6 @@ struct MenuScoresApp: App {
 
     var body: some Scene {
         MenuBarExtra {
-            Color.clear
-                .frame(width: 0, height: 0)
-                .accessibilityHidden(true)
-                .onAppear {
-                    AutoMonitorHub.shared.configure(
-                        isEnabled: { autoMonitorEnabled },
-                        favoriteRaw: { autoMonitorFavorite },
-                        refreshAll: { await refreshAllLeagues() },
-                        eventSources: { buildScoreboardEventSources() },
-                        tennisSources: { buildTennisSources() },
-                        apply: { title, id, state, prev in
-                            currentTitle = title
-                            currentGameID = id
-                            currentGameState = state
-                            previousGameState = prev
-                        }
-                    )
-                    Task { await AutoMonitorHub.shared.tick() }
-                }
-
             if enableNHL {
                 HockeyMenu(
                     title: "NHL",
@@ -595,7 +575,7 @@ struct MenuScoresApp: App {
                 SoccerMenu(
                     title: "Women's Super League",
                     viewModel: weplVM,
-                    league: "wepl",
+                    league: "WEPL",
                     fetchURL: Scoreboard.Urls.wepl,
                     currentTitle: $currentTitle,
                     currentGameID: $currentGameID,
@@ -1098,6 +1078,23 @@ struct MenuScoresApp: App {
             HStack {
                 Image(systemName: "dot.radiowaves.left.and.right")
                 Text(currentTitle)
+            }
+            .onAppear {
+                AutoMonitorHub.shared.configure(
+                    isEnabled: { autoMonitorEnabled },
+                    favoriteRaw: { autoMonitorFavorite },
+                    refreshAll: { await refreshAllLeagues() },
+                    eventSources: { buildScoreboardEventSources() },
+                    tennisSources: { buildTennisSources() },
+                    apply: { title, id, state in
+                        let priorForTransition = (currentGameID == id) ? currentGameState : nil
+                        currentTitle = title
+                        currentGameID = id
+                        currentGameState = state
+                        previousGameState = priorForTransition
+                    }
+                )
+                Task { await AutoMonitorHub.shared.tick() }
             }
             .onReceive(
                 Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()

--- a/MenuScores/MenuScoresApp.swift
+++ b/MenuScores/MenuScoresApp.swift
@@ -103,6 +103,9 @@ struct MenuScoresApp: App {
     @AppStorage("enableOMIHC") private var enableOMIHC = true
     @AppStorage("enableOWIHC") private var enableOWIHC = false
 
+    @AppStorage("autoMonitorEnabled") private var autoMonitorEnabled = false
+    @AppStorage("autoMonitorFavorite") private var autoMonitorFavorite = ""
+
     private func refreshAllLeagues() async {
         if enableNHL { await nhlVM.populateGames(from: Scoreboard.Urls.nhl) }
 
@@ -130,6 +133,30 @@ struct MenuScoresApp: App {
         if enablePGA { await pgaVM.populateGames(from: Scoreboard.Urls.pga) }
         if enableLPGA { await lpgaVM.populateGames(from: Scoreboard.Urls.lpga) }
 
+        if enableMLS { await mlsVM.populateGames(from: Scoreboard.Urls.mls) }
+        if enableNWSL { await nwslVM.populateGames(from: Scoreboard.Urls.nwsl) }
+        if enableUEFA { await uefaVM.populateGames(from: Scoreboard.Urls.uefa) }
+        if enableEUEFA { await euefaVM.populateGames(from: Scoreboard.Urls.euefa) }
+        if enableWUEFA { await wuefaVM.populateGames(from: Scoreboard.Urls.wuefa) }
+        if enableEPL { await eplVM.populateGames(from: Scoreboard.Urls.epl) }
+        if enableWEPL { await weplVM.populateGames(from: Scoreboard.Urls.wepl) }
+        if enableESP { await espVM.populateGames(from: Scoreboard.Urls.esp) }
+        if enableGER { await gerVM.populateGames(from: Scoreboard.Urls.ger) }
+        if enableITA { await itaVM.populateGames(from: Scoreboard.Urls.ita) }
+        if enableMEX { await mexVM.populateGames(from: Scoreboard.Urls.mex) }
+        if enableFRA { await fraVM.populateGames(from: Scoreboard.Urls.fra) }
+        if enableNED { await nedVM.populateGames(from: Scoreboard.Urls.ned) }
+        if enablePOR { await porVM.populateGames(from: Scoreboard.Urls.por) }
+
+        if enableFFWC { await ffwcVM.populateGames(from: Scoreboard.Urls.ffwc) }
+        if enableFFWWC { await ffwwcVM.populateGames(from: Scoreboard.Urls.ffwwc) }
+        if enableFFWCQUEFA { await ffwcquefaVM.populateGames(from: Scoreboard.Urls.ffwcquefa) }
+        if enableCONMEBOL { await conmebolVM.populateGames(from: Scoreboard.Urls.conmebol) }
+        if enableCONCACAF { await concacafVM.populateGames(from: Scoreboard.Urls.concacaf) }
+        if enableCAF { await cafVM.populateGames(from: Scoreboard.Urls.caf) }
+        if enableAFC { await afcVM.populateGames(from: Scoreboard.Urls.afc) }
+        if enableOFC { await ofcVM.populateGames(from: Scoreboard.Urls.ofc) }
+
         if enableATP { await atpVM.populateTennis(from: Scoreboard.Urls.atp) }
         if enableWTA { await wtaVM.populateTennis(from: Scoreboard.Urls.wta) }
 
@@ -145,6 +172,79 @@ struct MenuScoresApp: App {
 
         if enableOMIHC { await omihcVM.populateGames(from: Scoreboard.Urls.omihc) }
         if enableOWIHC { await owihcVM.populateGames(from: Scoreboard.Urls.owihc) }
+    }
+
+    @MainActor
+    private func buildScoreboardEventSources() -> [(league: String, games: [Event])] {
+        var rows: [(String, [Event])] = []
+        if enableNHL { rows.append(("NHL", nhlVM.games)) }
+        if enableHNCAAM { rows.append(("HNCAAM", hncaamVM.games)) }
+        if enableHNCAAF { rows.append(("HNCAAF", hncaafVM.games)) }
+
+        if enableNBA { rows.append(("NBA", nbaVM.games)) }
+        if enableWNBA { rows.append(("WNBA", wnbaVM.games)) }
+        if enableNCAAM { rows.append(("NCAA M", ncaamVM.games)) }
+        if enableNCAAF { rows.append(("NCAA F", ncaafVM.games)) }
+
+        if enableNFL { rows.append(("NFL", nflVM.games)) }
+        if enableFNCAA { rows.append(("FNCAA", fncaaVM.games)) }
+
+        if enableMLB { rows.append(("MLB", mlbVM.games)) }
+        if enableBNCAA { rows.append(("BNCAA", bncaaVM.games)) }
+        if enableSNCAA { rows.append(("SNCAA", sncaaVM.games)) }
+
+        if enableF1 { rows.append(("F1", f1VM.games)) }
+        if enableNC { rows.append(("NC", ncVM.games)) }
+        if enableNCS { rows.append(("NCS", ncsVM.games)) }
+        if enableNCT { rows.append(("NCT", nctVM.games)) }
+        if enableIRL { rows.append(("IRL", irlVM.games)) }
+
+        if enablePGA { rows.append(("PGA", pgaVM.games)) }
+        if enableLPGA { rows.append(("LPGA", lpgaVM.games)) }
+
+        if enableMLS { rows.append(("MLS", mlsVM.games)) }
+        if enableNWSL { rows.append(("NWSL", nwslVM.games)) }
+        if enableUEFA { rows.append(("UEFA", uefaVM.games)) }
+        if enableEUEFA { rows.append(("EUEFA", euefaVM.games)) }
+        if enableWUEFA { rows.append(("WUEFA", wuefaVM.games)) }
+        if enableEPL { rows.append(("EPL", eplVM.games)) }
+        if enableWEPL { rows.append(("wepl", weplVM.games)) }
+        if enableESP { rows.append(("ESP", espVM.games)) }
+        if enableGER { rows.append(("GER", gerVM.games)) }
+        if enableITA { rows.append(("ITA", itaVM.games)) }
+        if enableMEX { rows.append(("MEX", mexVM.games)) }
+        if enableFRA { rows.append(("FRA", fraVM.games)) }
+        if enableNED { rows.append(("NED", nedVM.games)) }
+        if enablePOR { rows.append(("POR", porVM.games)) }
+
+        if enableFFWC { rows.append(("FFWC", ffwcVM.games)) }
+        if enableFFWWC { rows.append(("FFWWC", ffwwcVM.games)) }
+        if enableFFWCQUEFA { rows.append(("FFWCQUEFA", ffwcquefaVM.games)) }
+        if enableCONMEBOL { rows.append(("CONMEBOL", conmebolVM.games)) }
+        if enableCONCACAF { rows.append(("CONCACAF", concacafVM.games)) }
+        if enableCAF { rows.append(("CAF", cafVM.games)) }
+        if enableAFC { rows.append(("AFC", afcVM.games)) }
+        if enableOFC { rows.append(("OFC", ofcVM.games)) }
+
+        if enableNLL { rows.append(("NLL", nllVM.games)) }
+        if enablePLL { rows.append(("PLL", pllVM.games)) }
+        if enableLNCAAM { rows.append(("LNCAAM", lncaamVM.games)) }
+        if enableLNCAAF { rows.append(("LNCAAF", lncaafVM.games)) }
+
+        if enableVNCAAM { rows.append(("VNCAAM", vncaamVM.games)) }
+        if enableVNCAAF { rows.append(("VNCAAF", vncaafVM.games)) }
+
+        if enableOMIHC { rows.append(("OMIHC", omihcVM.games)) }
+        if enableOWIHC { rows.append(("OWIHC", owihcVM.games)) }
+        return rows
+    }
+
+    @MainActor
+    private func buildTennisSources() -> [(league: String, games: [TennisEvent])] {
+        var rows: [(String, [TennisEvent])] = []
+        if enableATP { rows.append(("ATP", atpVM.tennisGames)) }
+        if enableWTA { rows.append(("WTA", wtaVM.tennisGames)) }
+        return rows
     }
 
     // Notification Settings
@@ -237,6 +337,26 @@ struct MenuScoresApp: App {
 
     var body: some Scene {
         MenuBarExtra {
+            Color.clear
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+                .onAppear {
+                    AutoMonitorHub.shared.configure(
+                        isEnabled: { autoMonitorEnabled },
+                        favoriteRaw: { autoMonitorFavorite },
+                        refreshAll: { await refreshAllLeagues() },
+                        eventSources: { buildScoreboardEventSources() },
+                        tennisSources: { buildTennisSources() },
+                        apply: { title, id, state, prev in
+                            currentTitle = title
+                            currentGameID = id
+                            currentGameState = state
+                            previousGameState = prev
+                        }
+                    )
+                    Task { await AutoMonitorHub.shared.tick() }
+                }
+
             if enableNHL {
                 HockeyMenu(
                     title: "NHL",
@@ -978,6 +1098,11 @@ struct MenuScoresApp: App {
             HStack {
                 Image(systemName: "dot.radiowaves.left.and.right")
                 Text(currentTitle)
+            }
+            .onReceive(
+                Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
+            ) { _ in
+                Task { await AutoMonitorHub.shared.tick() }
             }
         }
 

--- a/MenuScores/Utils/AutoMonitorFavorite.swift
+++ b/MenuScores/Utils/AutoMonitorFavorite.swift
@@ -1,0 +1,165 @@
+//
+//  AutoMonitorFavorite.swift
+//  MenuScores
+//
+
+import Foundation
+
+enum AutoMonitorFavorite {
+    static func normalizedQuery(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    /// F1 uses the race competition’s state when present; everything else uses the event status.
+    static func effectiveStandardState(league: String, game: Event) -> String {
+        if league == "F1", game.competitions.count > 4 {
+            return game.competitions[4].status.type.state
+        }
+        return game.status.type.state
+    }
+
+    static func parseEventStartDate(from isoString: String) -> Date? {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.dateFormat = "yyyy-MM-dd'T'HH:mmZ"
+        if let d = df.date(from: isoString) { return d }
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        if let d = df.date(from: isoString) { return d }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = iso.date(from: isoString) { return d }
+        iso.formatOptions = [.withInternetDateTime]
+        return iso.date(from: isoString)
+    }
+
+    static func isEventOnLocalCalendarToday(_ game: Event) -> Bool {
+        guard let start = parseEventStartDate(from: game.date) else { return false }
+        return Calendar.current.isDate(start, inSameDayAs: Date())
+    }
+
+    static func stringMatchesFavorite(_ value: String?, query: String) -> Bool {
+        guard let value, !value.isEmpty else { return false }
+        let v = value.lowercased()
+        if v == query || v.contains(query) || query.contains(v) { return true }
+        let parts = query.split { !$0.isLetter && !$0.isNumber }.map(String.init).filter { $0.count >= 3 }
+        guard !parts.isEmpty else { return false }
+        return parts.allSatisfy { v.contains($0) }
+    }
+
+    static func competitorMatches(_ c: Competitor, query: String) -> Bool {
+        if let team = c.team {
+            if stringMatchesFavorite(team.abbreviation, query: query) { return true }
+            if stringMatchesFavorite(team.displayName, query: query) { return true }
+            if stringMatchesFavorite(team.name, query: query) { return true }
+        }
+        if let a = c.athlete {
+            if stringMatchesFavorite(a.fullName, query: query) { return true }
+            if stringMatchesFavorite(a.displayName, query: query) { return true }
+            if stringMatchesFavorite(a.shortName, query: query) { return true }
+        }
+        return false
+    }
+
+    static func eventInvolvesFavorite(_ game: Event, query: String) -> Bool {
+        guard !query.isEmpty else { return false }
+        for competition in game.competitions {
+            guard let competitors = competition.competitors else { continue }
+            for c in competitors where competitorMatches(c, query: query) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Picks a favorite game: live (`in`) any day in the feed, or `pre` / `post` only when the event starts on the **local** calendar today.
+    /// Previously only `in` matched, so finished games (e.g. Blue Jays after the final) or not-yet-started games never appeared.
+    static func findStandardEventForAutoMonitor(
+        normalizedQuery: String,
+        sources: [(league: String, games: [Event])]
+    ) -> (league: String, game: Event)? {
+        guard !normalizedQuery.isEmpty else { return nil }
+
+        for (league, games) in sources {
+            for game in games {
+                guard eventInvolvesFavorite(game, query: normalizedQuery) else { continue }
+                let state = effectiveStandardState(league: league, game: game)
+                if state == "in" { return (league, game) }
+            }
+        }
+
+        for (league, games) in sources {
+            for game in games {
+                guard eventInvolvesFavorite(game, query: normalizedQuery) else { continue }
+                let state = effectiveStandardState(league: league, game: game)
+                if state == "pre", isEventOnLocalCalendarToday(game) { return (league, game) }
+            }
+        }
+
+        for (league, games) in sources {
+            for game in games {
+                guard eventInvolvesFavorite(game, query: normalizedQuery) else { continue }
+                let state = effectiveStandardState(league: league, game: game)
+                if state == "post", isEventOnLocalCalendarToday(game) { return (league, game) }
+            }
+        }
+
+        return nil
+    }
+
+    static func tennisAthleteMatches(_ a: TennisAthletes, query: String) -> Bool {
+        stringMatchesFavorite(a.fullName, query: query)
+            || stringMatchesFavorite(a.displayName, query: query)
+            || stringMatchesFavorite(a.shortName, query: query)
+    }
+
+    static func tennisAthleteMatches(_ a: TennisAthlete, query: String) -> Bool {
+        stringMatchesFavorite(a.fullName, query: query)
+            || stringMatchesFavorite(a.displayName, query: query)
+            || stringMatchesFavorite(a.shortName, query: query)
+    }
+
+    static func tennisCompetitorMatches(_ c: TennisCompetitor, query: String) -> Bool {
+        if let a = c.athlete, tennisAthleteMatches(a, query: query) { return true }
+        if let roster = c.roster?.athletes {
+            for a in roster where tennisAthleteMatches(a, query: query) { return true }
+        }
+        return false
+    }
+
+    static func isTennisCompetitionLive(game: TennisEvent, competition: TennisCompetition) -> Bool {
+        if competition.status?.type.state == "in" { return true }
+        return game.status.type.state == "in"
+    }
+
+    static func tennisMenubarTitle(competition: TennisCompetition) -> String {
+        let team1 =
+            competition.competitors?.first?.athlete?.shortName
+            ?? competition.competitors?.first?.roster?.shortDisplayName ?? "Player 1"
+        let team2 =
+            competition.competitors?.dropFirst().first?.athlete?.shortName
+            ?? competition.competitors?.dropFirst().first?.roster?.shortDisplayName ?? "Player 2"
+        return "\(team1) - \(team2)"
+    }
+
+    static func findLiveTennisEvent(
+        normalizedQuery: String,
+        sources: [(league: String, games: [TennisEvent])]
+    ) -> (league: String, game: TennisEvent, title: String)? {
+        guard !normalizedQuery.isEmpty else { return nil }
+        for (league, games) in sources {
+            for game in games {
+                for group in game.groupings {
+                    for competition in group.competitions {
+                        guard isTennisCompetitionLive(game: game, competition: competition) else { continue }
+                        guard let competitors = competition.competitors else { continue }
+                        if competitors.contains(where: { tennisCompetitorMatches($0, query: normalizedQuery) }) {
+                            return (league, game, tennisMenubarTitle(competition: competition))
+                        }
+                    }
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/MenuScores/Utils/AutoMonitorHub.swift
+++ b/MenuScores/Utils/AutoMonitorHub.swift
@@ -11,64 +11,115 @@ final class AutoMonitorHub {
 
     private var isEnabled: () -> Bool = { false }
     private var favoriteRaw: () -> String = { "" }
-    private var refreshAll: (() async -> Void)?
+    private var enabledLeagues: () -> [String] = { [] }
     private var eventSources: (() -> [(league: String, games: [Event])])?
     private var tennisSources: (() -> [(league: String, games: [TennisEvent])])?
-    private var apply: ((String, String, String) -> Void)?
+    private var apply: ((String, String, String, String) -> Void)?
+
+    private var autoMonitorScanIndex = 0
+    private var lastMatchedLeague: String?
 
     private init() {}
 
     func configure(
         isEnabled: @escaping () -> Bool,
         favoriteRaw: @escaping () -> String,
-        refreshAll: @escaping () async -> Void,
+        enabledLeagues: @escaping () -> [String],
         eventSources: @escaping () -> [(league: String, games: [Event])],
         tennisSources: @escaping () -> [(league: String, games: [TennisEvent])],
-        apply: @escaping (String, String, String) -> Void
+        apply: @escaping (String, String, String, String) -> Void
     ) {
         self.isEnabled = isEnabled
         self.favoriteRaw = favoriteRaw
-        self.refreshAll = refreshAll
+        self.enabledLeagues = enabledLeagues
         self.eventSources = eventSources
         self.tennisSources = tennisSources
         self.apply = apply
     }
 
-    func tick() async {
+    /// Leagues to refresh before `scanAndApply()` (one league while scanning, pinned league once matched).
+    func leaguesToRefreshThisTick() -> [String] {
+        guard isEnabled() else { return [] }
+        let q = AutoMonitorFavorite.normalizedQuery(favoriteRaw())
+        guard !q.isEmpty else { return [] }
+
+        if let lastMatchedLeague {
+            return [lastMatchedLeague]
+        }
+
+        let leagues = enabledLeagues()
+        guard !leagues.isEmpty else { return [] }
+        return [leagues[autoMonitorScanIndex % leagues.count]]
+    }
+
+    func scanAndApply() {
         guard isEnabled() else { return }
         let q = AutoMonitorFavorite.normalizedQuery(favoriteRaw())
         guard !q.isEmpty else { return }
 
-        await refreshAll?()
+        if let match = findMatch(normalizedQuery: q) {
+            applyMatch(match)
+            lastMatchedLeague = leagueCode(for: match)
+            return
+        }
 
-        if let fetchEvents = eventSources {
-            let events = fetchEvents()
-            if let found = AutoMonitorFavorite.findStandardEventForAutoMonitor(
-                normalizedQuery: q,
-                sources: events
-            ) {
-                let newState = found.game.status.type.state
-                apply?(
-                    displayText(for: found.game, league: found.league),
-                    found.game.id,
-                    newState
-                )
-                return
+        if lastMatchedLeague != nil {
+            lastMatchedLeague = nil
+        } else {
+            let leagues = enabledLeagues()
+            if !leagues.isEmpty {
+                autoMonitorScanIndex = (autoMonitorScanIndex + 1) % leagues.count
             }
+        }
+    }
+
+    private enum Match {
+        case standard(league: String, game: Event)
+        case tennis(league: String, game: TennisEvent, title: String)
+    }
+
+    private func findMatch(normalizedQuery: String) -> Match? {
+        if let fetchEvents = eventSources,
+           let found = AutoMonitorFavorite.findStandardEventForAutoMonitor(
+               normalizedQuery: normalizedQuery,
+               sources: fetchEvents()
+           )
+        {
+            return .standard(league: found.league, game: found.game)
         }
 
         if let fetchTennis = tennisSources,
            let tennis = AutoMonitorFavorite.findLiveTennisEvent(
-               normalizedQuery: q,
+               normalizedQuery: normalizedQuery,
                sources: fetchTennis()
            )
         {
-            let newState = tennis.game.status.type.state
+            return .tennis(league: tennis.league, game: tennis.game, title: tennis.title)
+        }
+
+        return nil
+    }
+
+    private func leagueCode(for match: Match) -> String {
+        switch match {
+        case let .standard(league, _): return league
+        case let .tennis(league, _, _): return league
+        }
+    }
+
+    private func applyMatch(_ match: Match) {
+        switch match {
+        case let .standard(league, game):
+            let newState = AutoMonitorFavorite.effectiveStandardState(league: league, game: game)
             apply?(
-                tennis.title,
-                tennis.game.id,
-                newState
+                displayText(for: game, league: league),
+                game.id,
+                newState,
+                league
             )
+        case let .tennis(league, game, title):
+            let newState = game.status.type.state
+            apply?(title, game.id, newState, league)
         }
     }
 }

--- a/MenuScores/Utils/AutoMonitorHub.swift
+++ b/MenuScores/Utils/AutoMonitorHub.swift
@@ -1,0 +1,76 @@
+//
+//  AutoMonitorHub.swift
+//  MenuScores
+//
+
+import Foundation
+
+@MainActor
+final class AutoMonitorHub {
+    static let shared = AutoMonitorHub()
+
+    private var isEnabled: () -> Bool = { false }
+    private var favoriteRaw: () -> String = { "" }
+    private var refreshAll: (() async -> Void)?
+    private var eventSources: (() -> [(league: String, games: [Event])])?
+    private var tennisSources: (() -> [(league: String, games: [TennisEvent])])?
+    private var apply: ((String, String, String, String?) -> Void)?
+
+    private init() {}
+
+    func configure(
+        isEnabled: @escaping () -> Bool,
+        favoriteRaw: @escaping () -> String,
+        refreshAll: @escaping () async -> Void,
+        eventSources: @escaping () -> [(league: String, games: [Event])],
+        tennisSources: @escaping () -> [(league: String, games: [TennisEvent])],
+        apply: @escaping (String, String, String, String?) -> Void
+    ) {
+        self.isEnabled = isEnabled
+        self.favoriteRaw = favoriteRaw
+        self.refreshAll = refreshAll
+        self.eventSources = eventSources
+        self.tennisSources = tennisSources
+        self.apply = apply
+    }
+
+    func tick() async {
+        guard isEnabled() else { return }
+        let q = AutoMonitorFavorite.normalizedQuery(favoriteRaw())
+        guard !q.isEmpty else { return }
+
+        await refreshAll?()
+
+        if let fetchEvents = eventSources {
+            let events = fetchEvents()
+            if let found = AutoMonitorFavorite.findStandardEventForAutoMonitor(
+                normalizedQuery: q,
+                sources: events
+            ) {
+                let newState = found.game.status.type.state
+                apply?(
+                    displayText(for: found.game, league: found.league),
+                    found.game.id,
+                    newState,
+                    newState
+                )
+                return
+            }
+        }
+
+        if let fetchTennis = tennisSources,
+           let tennis = AutoMonitorFavorite.findLiveTennisEvent(
+               normalizedQuery: q,
+               sources: fetchTennis()
+           )
+        {
+            let newState = tennis.game.status.type.state
+            apply?(
+                tennis.title,
+                tennis.game.id,
+                newState,
+                newState
+            )
+        }
+    }
+}

--- a/MenuScores/Utils/AutoMonitorHub.swift
+++ b/MenuScores/Utils/AutoMonitorHub.swift
@@ -14,7 +14,7 @@ final class AutoMonitorHub {
     private var refreshAll: (() async -> Void)?
     private var eventSources: (() -> [(league: String, games: [Event])])?
     private var tennisSources: (() -> [(league: String, games: [TennisEvent])])?
-    private var apply: ((String, String, String, String?) -> Void)?
+    private var apply: ((String, String, String) -> Void)?
 
     private init() {}
 
@@ -24,7 +24,7 @@ final class AutoMonitorHub {
         refreshAll: @escaping () async -> Void,
         eventSources: @escaping () -> [(league: String, games: [Event])],
         tennisSources: @escaping () -> [(league: String, games: [TennisEvent])],
-        apply: @escaping (String, String, String, String?) -> Void
+        apply: @escaping (String, String, String) -> Void
     ) {
         self.isEnabled = isEnabled
         self.favoriteRaw = favoriteRaw
@@ -51,7 +51,6 @@ final class AutoMonitorHub {
                 apply?(
                     displayText(for: found.game, league: found.league),
                     found.game.id,
-                    newState,
                     newState
                 )
                 return
@@ -68,7 +67,6 @@ final class AutoMonitorHub {
             apply?(
                 tennis.title,
                 tennis.game.id,
-                newState,
                 newState
             )
         }

--- a/MenuScores/Utils/GameState.swift
+++ b/MenuScores/Utils/GameState.swift
@@ -5,6 +5,32 @@
 //  Created by Daniyal Master on 2025-05-10.
 //
 
+import Foundation
+
+func eventDetailsURL(for gameID: String, in sources: [(league: String, games: [Event])]) -> URL? {
+    guard !gameID.isEmpty, gameID != "0" else { return nil }
+    for source in sources {
+        if let game = source.games.first(where: { $0.id == gameID }),
+           let href = game.links?.first?.href
+        {
+            return URL(string: href)
+        }
+    }
+    return nil
+}
+
+func tennisDetailsURL(for gameID: String, in sources: [(league: String, games: [TennisEvent])]) -> URL? {
+    guard !gameID.isEmpty, gameID != "0" else { return nil }
+    for source in sources {
+        if let game = source.games.first(where: { $0.id == gameID }),
+           let href = game.links?.first?.href
+        {
+            return URL(string: href)
+        }
+    }
+    return nil
+}
+
 func displayText(for game: Event, league: String) -> String {
     guard let competition = game.competitions.first,
           let competitors = competition.competitors,

--- a/MenuScores/Utils/LeagueMenuShell.swift
+++ b/MenuScores/Utils/LeagueMenuShell.swift
@@ -1,0 +1,28 @@
+//
+//  LeagueMenuShell.swift
+//  MenuScores
+//
+
+import SwiftUI
+
+/// Root `Menu` with a stable identity; live score updates stay in `content` only.
+struct LeagueMenuShell<Content: View>: View {
+    let title: String
+    let league: String
+    let onAppearAction: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        Menu(title) {
+            content()
+        }
+        .id("menu-league-\(league)")
+        .onAppear(perform: onAppearAction)
+    }
+}
+
+extension View {
+    func stableMenuBarItem(_ id: String) -> some View {
+        self.id(id)
+    }
+}

--- a/MenuScores/Utils/MarqueeText.swift
+++ b/MenuScores/Utils/MarqueeText.swift
@@ -34,6 +34,8 @@ struct MarqueeText: View {
     @State private var animate = false
     @State private var textSize: CGSize = .zero
     @State private var offset: CGFloat = 0
+    @State private var configuredText = ""
+    @State private var configuredFrameWidth: CGFloat = 0
 
     init(_ text: Binding<String>, font: Font = .body, nsFont: NSFont.TextStyle = .body, textColor: Color = .primary, backgroundColor: Color = .clear, minDuration: Double = 3.0, frameWidth: CGFloat = 300) {
         _text = text
@@ -61,31 +63,61 @@ struct MarqueeText: View {
                 .font(font)
                 .foregroundColor(textColor)
                 .fixedSize(horizontal: true, vertical: false)
-                .offset(x: self.animate ? offset : 0)
+                .offset(x: animate ? offset : 0)
                 .animation(
-                    self.animate ?
+                    animate ?
                         .linear(duration: Double(textSize.width / 40))
                         .delay(minDuration)
                         .repeatForever(autoreverses: false) : .none,
-                    value: self.animate
+                    value: animate
                 )
                 .background(backgroundColor)
                 .modifier(MeasureSizeModifier())
                 .onPreferenceChange(SizePreferenceKey.self) { size in
-                    self.textSize = CGSize(width: size.width / 2, height: NSFont.preferredFont(forTextStyle: nsFont).pointSize)
-                    self.animate = false
-                    self.offset = 0
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                        if needsScrolling {
-                            self.animate = true
-                            self.offset = -(textSize.width + 10)
-                        }
-                    }
+                    let measuredWidth = size.width / 2
+                    let measuredHeight = NSFont.preferredFont(forTextStyle: nsFont).pointSize
+                    let newSize = CGSize(width: measuredWidth, height: measuredHeight)
+
+                    guard measuredWidth > 0 else { return }
+
+                    let widthDelta = abs(measuredWidth - textSize.width)
+                    let frameChanged = abs(frameWidth - configuredFrameWidth) > 0.5
+                    let textChanged = text != configuredText
+
+                    guard widthDelta > 0.5 || frameChanged || textChanged || textSize == .zero else { return }
+
+                    textSize = newSize
+                    updateScrollingState(forceRestart: textChanged || frameChanged)
                 }
             }
             .frame(width: frameWidth, alignment: .leading)
             .clipped()
         }
         .frame(height: textSize.height * 1.3)
+        .onChange(of: text) { _ in
+            updateScrollingState(forceRestart: true)
+        }
+        .onChange(of: frameWidth) { _ in
+            updateScrollingState(forceRestart: true)
+        }
+    }
+
+    private func updateScrollingState(forceRestart: Bool) {
+        configuredText = text
+        configuredFrameWidth = frameWidth
+
+        guard needsScrolling else {
+            animate = false
+            offset = 0
+            return
+        }
+
+        let targetOffset = -(textSize.width + 10)
+        if forceRestart || !animate || offset != targetOffset {
+            animate = false
+            offset = 0
+            animate = true
+            offset = targetOffset
+        }
     }
 }

--- a/MenuScores/Utils/PinnedGameSync.swift
+++ b/MenuScores/Utils/PinnedGameSync.swift
@@ -1,0 +1,50 @@
+//
+//  PinnedGameSync.swift
+//  MenuScores
+//
+
+import Foundation
+
+enum PinnedGameSync {
+    @MainActor
+    static func syncStandardEvent(
+        gameID: String,
+        league: String,
+        eventSources: [(league: String, games: [Event])],
+        currentTitle: inout String,
+        currentGameState: inout String,
+        previousGameState: inout String?,
+        notiGameStart: Bool,
+        notiGameComplete: Bool
+    ) {
+        guard !gameID.isEmpty, gameID != "0" else { return }
+        guard let updatedGame = eventSources
+            .first(where: { $0.league == league })?
+            .games
+            .first(where: { $0.id == gameID })
+        else { return }
+
+        let pinnedToNotch = NotchViewModel.shared.notch != nil
+            && (NotchViewModel.shared.currentGameID == gameID || NotchViewModel.shared.game?.id == gameID)
+
+        if pinnedToNotch {
+            currentTitle = ""
+            NotchViewModel.shared.game = updatedGame
+        } else {
+            currentTitle = displayText(for: updatedGame, league: league)
+        }
+
+        let newState = AutoMonitorFavorite.effectiveStandardState(league: league, game: updatedGame)
+
+        if notiGameStart, previousGameState != "in", newState == "in" {
+            gameStartNotification(gameId: gameID, gameTitle: currentTitle, newState: newState)
+        }
+        if notiGameComplete, previousGameState != "post", newState == "post" {
+            gameCompleteNotification(gameId: gameID, gameTitle: currentTitle, newState: newState)
+        }
+
+        previousGameState = newState
+        currentGameState = newState
+        NotchViewModel.shared.currentGameState = newState
+    }
+}

--- a/MenuScores/Utils/RefreshCoordinator.swift
+++ b/MenuScores/Utils/RefreshCoordinator.swift
@@ -1,0 +1,67 @@
+//
+//  RefreshCoordinator.swift
+//  MenuScores
+//
+
+import Combine
+import Foundation
+
+enum RefreshInterval {
+    static func timeInterval(for selectedOption: String) -> TimeInterval {
+        switch selectedOption {
+        case "10 seconds": return 10
+        case "15 seconds": return 15
+        case "20 seconds": return 20
+        case "30 seconds": return 30
+        case "40 seconds": return 40
+        case "50 seconds": return 50
+        case "1 minute": return 60
+        case "2 minutes": return 120
+        case "5 minutes": return 300
+        default: return 15
+        }
+    }
+}
+
+/// Single main-run-loop timer for background score updates (replaces per-menu timers).
+@MainActor
+final class RefreshCoordinator {
+    static let shared = RefreshCoordinator()
+
+    private var timerCancellable: AnyCancellable?
+    private var interval: TimeInterval = 15
+    private var onTick: (() async -> Void)?
+
+    private(set) var isActive = false
+
+    private init() {}
+
+    func configure(interval: TimeInterval, onTick: @escaping () async -> Void) {
+        self.interval = interval
+        self.onTick = onTick
+        reconcileTimer()
+    }
+
+    func setInterval(_ interval: TimeInterval) {
+        self.interval = interval
+        reconcileTimer()
+    }
+
+    func setShouldRun(_ shouldRun: Bool) {
+        guard shouldRun != isActive else { return }
+        isActive = shouldRun
+        reconcileTimer()
+    }
+
+    private func reconcileTimer() {
+        timerCancellable?.cancel()
+        timerCancellable = nil
+        guard isActive, let onTick else { return }
+
+        timerCancellable = Timer.publish(every: interval, on: .main, in: .default)
+            .autoconnect()
+            .sink { _ in
+                Task { await onTick() }
+            }
+    }
+}

--- a/MenuScores/Utils/TennisReponse.swift
+++ b/MenuScores/Utils/TennisReponse.swift
@@ -96,8 +96,7 @@ struct TennisCompetitor: Decodable, Identifiable {
     let linescores: [TennisLinesScore]?
 }
 
-struct TennisLinesScore: Decodable, Identifiable {
-    let id = UUID()
+struct TennisLinesScore: Decodable {
     let winner: Bool?
     let value: Int?
 }

--- a/MenuScores/Views/Notch Views/Expanded.swift
+++ b/MenuScores/Views/Notch Views/Expanded.swift
@@ -1119,7 +1119,7 @@ struct Info: View {
 
                                                         if let linescores = competitor.linescores {
                                                             HStack(spacing: 4) {
-                                                                ForEach(linescores) { linescore in
+                                                                ForEach(Array(linescores.enumerated()), id: \.offset) { _, linescore in
                                                                     Text("\(linescore.value ?? 0)  ")
                                                                 }
                                                             }

--- a/MenuScores/Views/Settings Views/BehaviorSettings.swift
+++ b/MenuScores/Views/Settings Views/BehaviorSettings.swift
@@ -14,6 +14,9 @@ struct BehaviorSettingsView: View {
     @AppStorage("notiGameStart") private var notiGameStart = false
     @AppStorage("notiGameComplete") private var notiGameComplete = false
 
+    @AppStorage("autoMonitorEnabled") private var autoMonitorEnabled = false
+    @AppStorage("autoMonitorFavorite") private var autoMonitorFavorite = ""
+
     @AppStorage("enableNotch") private var enableNotch = true
 //    @AppStorage("enableInlineView") private var enableInlineView = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
@@ -103,6 +106,32 @@ struct BehaviorSettingsView: View {
                             .frame(width: 150)
                         }
                     }
+                }
+
+                Section {
+                    Toggle(isOn: $autoMonitorEnabled) {
+                        HStack {
+                            Image(systemName: "star.circle")
+                                .foregroundColor(.secondary)
+                            Text("Auto-Monitor")
+                        }
+                    }
+
+                    TextField("Team or competitor", text: $autoMonitorFavorite)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(!autoMonitorEnabled)
+                        .help(
+                            "Abbreviation or name (e.g. TOR, Lakers, Verstappen). Shows live games in any enabled league; for today's calendar day also shows pregame and final for that favorite."
+                        )
+
+                    Text(
+                        "Matches enabled leagues only. Uses the same refresh interval as score updates."
+                    )
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                } header: {
+                    Text("Favorite")
                 }
 
                 Section {

--- a/MenuScores/Views/Sport Views/Baseball.swift
+++ b/MenuScores/Views/Sport Views/Baseball.swift
@@ -11,14 +11,11 @@ import SwiftUI
 
 struct BaseballMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -28,27 +25,48 @@ struct BaseballMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            BaseballMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct BaseballMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -68,9 +86,6 @@ struct BaseballMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -86,10 +101,8 @@ struct BaseballMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -158,42 +171,5 @@ struct BaseballMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Baseball.swift
+++ b/MenuScores/Views/Sport Views/Baseball.swift
@@ -67,6 +67,7 @@ struct BaseballMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Basketball.swift
+++ b/MenuScores/Views/Sport Views/Basketball.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct BasketballMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct BasketballMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            BasketballMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct BasketballMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -67,9 +85,6 @@ struct BasketballMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +100,8 @@ struct BasketballMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -157,42 +170,5 @@ struct BasketballMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Basketball.swift
+++ b/MenuScores/Views/Sport Views/Basketball.swift
@@ -66,6 +66,7 @@ struct BasketballMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/F1.swift
+++ b/MenuScores/Views/Sport Views/F1.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct F1Menu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct F1Menu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            F1MenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct F1MenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             if !viewModel.games.isEmpty {
                 ForEach(Array(viewModel.games.enumerated()), id: \.1.id) { _, game in
                     if let country = game.circuit?.address.country {
@@ -61,9 +79,6 @@ struct F1Menu: View {
                                     currentGameID = game.id
                                     currentGameState = game.status.type.state
                                     LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                    pinnedByMenubar = true
-                                    pinnedByNotch = false
                                 } label: {
                                     HStack {
                                         Image(systemName: "menubar.rectangle")
@@ -79,10 +94,8 @@ struct F1Menu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
 
-                                        pinnedByNotch = true
-                                        pinnedByMenubar = false
-
                                         notchViewModel.game = game
+                                        NotchViewModel.shared.currentGameID = game.id
 
                                         Task {
                                             if let existingNotch = NotchViewModel.shared.notch {
@@ -183,42 +196,5 @@ struct F1Menu: View {
                     .foregroundColor(.gray)
                     .padding()
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/F1.swift
+++ b/MenuScores/Views/Sport Views/F1.swift
@@ -60,6 +60,7 @@ struct F1Menu: View {
                                     currentTitle = displayText(for: game, league: league)
                                     currentGameID = game.id
                                     currentGameState = game.status.type.state
+                                    LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                     pinnedByMenubar = true
                                     pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Football.swift
+++ b/MenuScores/Views/Sport Views/Football.swift
@@ -66,6 +66,7 @@ struct FootballMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Football.swift
+++ b/MenuScores/Views/Sport Views/Football.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct FootballMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct FootballMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            FootballMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct FootballMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -67,9 +85,6 @@ struct FootballMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +100,8 @@ struct FootballMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -157,42 +170,5 @@ struct FootballMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Golf.swift
+++ b/MenuScores/Views/Sport Views/Golf.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct GolfMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct GolfMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            GolfMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct GolfMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -67,9 +85,6 @@ struct GolfMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +100,8 @@ struct GolfMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -168,7 +181,7 @@ struct GolfMenu: View {
                                 } label: {
                                     HStack {
                                         AsyncImage(
-                                            url: URL(string: leagueLogoURL(for: league))
+                                            url: URL(string: "https://a.espncdn.com/combiner/i?img=/redesign/assets/img/icons/ESPN-icon-golf.png&h=80&w=80&scale=crop&cquality=40")
                                         ) { image in
                                             image.resizable().scaledToFit()
                                         } placeholder: {
@@ -183,46 +196,5 @@ struct GolfMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
-}
-
-private func leagueLogoURL(for league: String) -> String {
-    return "https://a.espncdn.com/combiner/i?img=/redesign/assets/img/icons/ESPN-icon-golf.png&w=64&h=64&scale=crop&cquality=40&location=origin"
 }

--- a/MenuScores/Views/Sport Views/Golf.swift
+++ b/MenuScores/Views/Sport Views/Golf.swift
@@ -66,6 +66,7 @@ struct GolfMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Hockey.swift
+++ b/MenuScores/Views/Sport Views/Hockey.swift
@@ -66,6 +66,7 @@ struct HockeyMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Hockey.swift
+++ b/MenuScores/Views/Sport Views/Hockey.swift
@@ -10,14 +10,10 @@ import SwiftUI
 
 struct HockeyMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
-
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +23,45 @@ struct HockeyMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
-
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            HockeyMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct HockeyMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -68,8 +82,6 @@ struct HockeyMenu: View {
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +97,8 @@ struct HockeyMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -158,42 +168,5 @@ struct HockeyMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Lacrosse.swift
+++ b/MenuScores/Views/Sport Views/Lacrosse.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct LacrosseMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct LacrosseMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            LacrosseMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct LacrosseMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -67,9 +85,6 @@ struct LacrosseMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +100,8 @@ struct LacrosseMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -144,42 +157,5 @@ struct LacrosseMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Lacrosse.swift
+++ b/MenuScores/Views/Sport Views/Lacrosse.swift
@@ -66,6 +66,7 @@ struct LacrosseMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Racing.swift
+++ b/MenuScores/Views/Sport Views/Racing.swift
@@ -59,6 +59,7 @@ struct RacingMenu: View {
                             currentTitle = displayText(for: game, league: league)
                             currentGameID = game.id
                             currentGameState = game.status.type.state
+                            LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                             pinnedByMenubar = true
                             pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Racing.swift
+++ b/MenuScores/Views/Sport Views/Racing.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct RacingMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct RacingMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            RacingMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct RacingMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             Text(formattedDate(from: viewModel.games.first?.date ?? "Invalid Date"))
                 .font(.headline)
             Divider().padding(.bottom)
@@ -60,9 +78,6 @@ struct RacingMenu: View {
                             currentGameID = game.id
                             currentGameState = game.status.type.state
                             LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                            pinnedByMenubar = true
-                            pinnedByNotch = false
                         } label: {
                             HStack {
                                 Image(systemName: "menubar.rectangle")
@@ -77,9 +92,6 @@ struct RacingMenu: View {
                             Button {
                                 currentGameID = game.id
                                 currentGameState = game.status.type.state
-
-                                pinnedByNotch = true
-                                pinnedByMenubar = false
 
                                 notchViewModel.game = game
 
@@ -167,42 +179,5 @@ struct RacingMenu: View {
                     .foregroundColor(.gray)
                     .padding()
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Soccer.swift
+++ b/MenuScores/Views/Sport Views/Soccer.swift
@@ -59,6 +59,7 @@ struct SoccerMenu: View {
                             currentTitle = displayText(for: game, league: league)
                             currentGameID = game.id
                             currentGameState = game.status.type.state
+                            LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                             pinnedByMenubar = true
                             pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Soccer.swift
+++ b/MenuScores/Views/Sport Views/Soccer.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct SoccerMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct SoccerMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            SoccerMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct SoccerMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             Text(formattedDate(from: viewModel.games.first?.date ?? "Invalid Date"))
                 .font(.headline)
             Divider().padding(.bottom)
@@ -60,9 +78,6 @@ struct SoccerMenu: View {
                             currentGameID = game.id
                             currentGameState = game.status.type.state
                             LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                            pinnedByMenubar = true
-                            pinnedByNotch = false
                         } label: {
                             HStack {
                                 Image(systemName: "menubar.rectangle")
@@ -77,9 +92,6 @@ struct SoccerMenu: View {
                             Button {
                                 currentGameID = game.id
                                 currentGameState = game.status.type.state
-
-                                pinnedByNotch = true
-                                pinnedByMenubar = false
 
                                 notchViewModel.game = game
 
@@ -151,42 +163,5 @@ struct SoccerMenu: View {
                     .foregroundColor(.gray)
                     .padding()
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Tennis.swift
+++ b/MenuScores/Views/Sport Views/Tennis.swift
@@ -76,6 +76,7 @@ struct TennisMenu: View {
                                                             currentTitle = tennisTitle
                                                             currentGameID = game.id
                                                             currentGameState = game.status.type.state
+                                                            LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                                             pinnedByMenubar = true
                                                             pinnedByNotch = false

--- a/MenuScores/Views/Sport Views/Tennis.swift
+++ b/MenuScores/Views/Sport Views/Tennis.swift
@@ -10,14 +10,10 @@ import SwiftUI
 
 struct TennisMenu: View {
     let title: String
-    @ObservedObject var viewModel: TennisListView
+    var viewModel: TennisListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
-
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +23,45 @@ struct TennisMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
-
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateTennis(from: fetchURL)
+            }
+        }) {
+            TennisMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct TennisMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: TennisListView
+    let league: String
+    let fetchURL: URL
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             if !viewModel.tennisGames.isEmpty {
                 ForEach(Array(viewModel.tennisGames.enumerated()), id: \.1.id) { _, game in
                     Menu {
@@ -78,8 +92,6 @@ struct TennisMenu: View {
                                                             currentGameState = game.status.type.state
                                                             LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
-                                                            pinnedByMenubar = true
-                                                            pinnedByNotch = false
                                                         } label: {
                                                             HStack {
                                                                 Image(systemName: "menubar.rectangle")
@@ -95,10 +107,8 @@ struct TennisMenu: View {
                                                                 currentGameID = game.id
                                                                 currentGameState = game.status.type.state
 
-                                                                pinnedByNotch = true
-                                                                pinnedByMenubar = false
-
                                                                 notchViewModel.tennisCompetition = competition
+                                                                NotchViewModel.shared.currentGameID = game.id
 
                                                                 Task {
                                                                     if let existingNotch = NotchViewModel.shared.notch {
@@ -175,12 +185,5 @@ struct TennisMenu: View {
                     .foregroundColor(.gray)
                     .padding()
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateTennis(from: fetchURL)
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/UFC.swift
+++ b/MenuScores/Views/Sport Views/UFC.swift
@@ -16,9 +16,6 @@ struct UFCMenu: View {
 
     @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
-
     @Binding var currentTitle: String
     @Binding var currentGameID: String
     @Binding var currentGameState: String
@@ -26,25 +23,6 @@ struct UFCMenu: View {
 
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
-
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
-
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
-        }
-    }
 
     var body: some View {}
 }

--- a/MenuScores/Views/Sport Views/Volleyball.swift
+++ b/MenuScores/Views/Sport Views/Volleyball.swift
@@ -10,14 +10,11 @@ import SwiftUI
 
 struct VolleyballMenu: View {
     let title: String
-    @ObservedObject var viewModel: GamesListView
+    var viewModel: GamesListView
     let league: String
     let fetchURL: URL
 
-    @StateObject private var notchViewModel = NotchViewModel()
 
-    @State private var pinnedByNotch = false
-    @State private var pinnedByMenubar = false
 
     @Binding var currentTitle: String
     @Binding var currentGameID: String
@@ -27,27 +24,48 @@ struct VolleyballMenu: View {
     @AppStorage("enableNotch") private var enableNotch = true
     @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
 
-    @AppStorage("refreshInterval") private var selectedOption = "15 seconds"
-    @AppStorage("notiGameStart") private var notiGameStart = false
-    @AppStorage("notiGameComplete") private var notiGameComplete = false
 
-    private var refreshInterval: TimeInterval {
-        switch selectedOption {
-        case "10 seconds": return 10
-        case "15 seconds": return 15
-        case "20 seconds": return 20
-        case "30 seconds": return 30
-        case "40 seconds": return 40
-        case "50 seconds": return 50
-        case "1 minute": return 60
-        case "2 minutes": return 120
-        case "5 minutes": return 300
-        default: return 15
+       var body: some View {
+        LeagueMenuShell(title: title, league: league, onAppearAction: {
+            LeagueSelectionModel.shared.currentLeague = league
+            Task {
+                await viewModel.populateGames(from: fetchURL)
+            }
+        }) {
+            VolleyballMenuContent(
+                title: title,
+                viewModel: viewModel,
+                league: league,
+                fetchURL: fetchURL,
+                currentTitle: $currentTitle,
+                currentGameID: $currentGameID,
+                currentGameState: $currentGameState,
+                previousGameState: $previousGameState
+            )
         }
     }
+}
+
+private struct VolleyballMenuContent: View {
+    let title: String
+    @ObservedObject var viewModel: GamesListView
+    let league: String
+    let fetchURL: URL
+
+
+
+    @Binding var currentTitle: String
+    @Binding var currentGameID: String
+    @Binding var currentGameState: String
+    @Binding var previousGameState: String?
+
+    @AppStorage("enableNotch") private var enableNotch = true
+    @AppStorage("notchScreenIndex") private var notchScreenIndex = 0
+
+
+       @StateObject private var notchViewModel = NotchViewModel()
 
     var body: some View {
-        Menu(title) {
             let groupedGames = Dictionary(grouping: viewModel.games) { game in
                 formattedDate(from: game.date)
             }
@@ -67,9 +85,6 @@ struct VolleyballMenu: View {
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
                                         LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
-
-                                        pinnedByMenubar = true
-                                        pinnedByNotch = false
                                     } label: {
                                         HStack {
                                             Image(systemName: "menubar.rectangle")
@@ -85,10 +100,8 @@ struct VolleyballMenu: View {
                                             currentGameID = game.id
                                             currentGameState = game.status.type.state
 
-                                            pinnedByNotch = true
-                                            pinnedByMenubar = false
-
                                             notchViewModel.game = game
+                                            NotchViewModel.shared.currentGameID = game.id
 
                                             Task {
                                                 if let existingNotch = NotchViewModel.shared.notch {
@@ -144,42 +157,5 @@ struct VolleyballMenu: View {
                     }
                 }
             }
-        }
-        .onAppear {
-            LeagueSelectionModel.shared.currentLeague = league
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-            }
-        }
-        .onReceive(
-            Timer.publish(every: refreshInterval, on: .main, in: .common).autoconnect()
-        ) { _ in
-            Task {
-                await viewModel.populateGames(from: fetchURL)
-                if let updatedGame = viewModel.games.first(where: { $0.id == currentGameID }) {
-                    if pinnedByMenubar {
-                        currentTitle = displayText(for: updatedGame, league: league)
-                    } else if pinnedByNotch {
-                        currentTitle = ""
-                    }
-
-                    let newState = updatedGame.status.type.state
-
-                    if notiGameStart && previousGameState != "in" && newState == "in" {
-                        gameStartNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-                    if notiGameComplete && previousGameState != "post" && newState == "post" {
-                        gameCompleteNotification(gameId: currentGameID, gameTitle: currentTitle, newState: newState)
-                    }
-
-                    previousGameState = newState
-                    currentGameState = newState
-
-                    if pinnedByNotch {
-                        notchViewModel.game = updatedGame
-                    }
-                }
-            }
-        }
     }
 }

--- a/MenuScores/Views/Sport Views/Volleyball.swift
+++ b/MenuScores/Views/Sport Views/Volleyball.swift
@@ -66,6 +66,7 @@ struct VolleyballMenu: View {
                                         currentTitle = displayText(for: game, league: league)
                                         currentGameID = game.id
                                         currentGameState = game.status.type.state
+                                        LeagueSelectionModel.shared.setPinnedDetailURL(from: game)
 
                                         pinnedByMenubar = true
                                         pinnedByNotch = false


### PR DESCRIPTION
## Summary

Adds an **Auto-Monitor** option under Settings → Behavior so users can enter a favorite team or competitor string. While enabled, the app refreshes enabled league scoreboards on the menubar refresh timer (and once when the extra appears), finds a matching event, and updates the menubar title.

## Behavior

- Matches **abbreviation**, **display name**, **name**, and **athlete** fields (case-insensitive, substring and light multi-token matching).
- Prefers **live** (`in`) games; for the **local calendar today** also considers **pregame** (`pre`) and **final** (`post`) so same-day finished or upcoming games still show.
- Includes **tennis** (ATP/WTA) when those leagues are enabled.
- **`refreshAllLeagues`** now also fetches soccer and qualifier feeds so Auto-Monitor and the menubar **Refresh** action stay consistent with enabled leagues.
- **WEPL** uses the same `WEPL` league tag as `periodPrefix` / other soccer menus.

## Implementation notes

- **`AutoMonitorFavorite`**: matching + date parsing + selection order.
- **`AutoMonitorHub`**: coordinates refresh, search, and menubar updates without relying on lazy-loaded menu content (configure + initial tick on the **label** `onAppear`).
- **Notifications**: apply path keeps **`previousGameState`** as the prior `currentGameState` when the game id is unchanged so start/complete checks in sport menus can still see transitions.
- **`TennisLinesScore`**: removed synthetic `UUID` `id` that broke `Decodable` synthesis; notch UI uses enumerated `ForEach` ids.

## Testing

- [ ] Enable MLB + Auto-Monitor with a team string; confirm menubar updates for pre / in / post today.
- [ ] Toggle notifications and confirm transitions still fire when the same game is followed via a league menu or auto-monitor.